### PR TITLE
Support for continuous joints and fixed joints in URDF

### DIFF
--- a/v3/dynamics/jcalc.m
+++ b/v3/dynamics/jcalc.m
@@ -65,6 +65,9 @@ switch code
     R = T(1:3,1:3);
     p = T(1:3,4);
     Xj = [R zeros(3); skew(p)*R R];
+  case 'fixed'
+    Xj = eye(6);
+    S = [0;0;0;0;0;0]; 
   otherwise
     error( 'unrecognised joint code ''%s''', code );
 end

--- a/v3/models/URDF_to_spatialv2_model.m
+++ b/v3/models/URDF_to_spatialv2_model.m
@@ -115,7 +115,7 @@ function [model,  robot] = URDF_to_spatialv2_model(file, addRandomInertia, remov
         model.I{i} = X_i_iplus'*I_i*X_i_iplus;
     end
 
-    if removeFixedJoints:
+    if removeFixedJoints
         model = remove_fixed_joints(model);
     end
 end

--- a/v3/models/remove_fixed_joints.m
+++ b/v3/models/remove_fixed_joints.m
@@ -1,0 +1,45 @@
+function model = remove_fixed_joints(model)
+% Update inertias and transforms
+for i = 1:model.NB
+    if ~strcmp(model.jtype{i}, 'fixed')
+        continue;
+    end
+    
+    parent = model.parent(i);
+    children = find(model.parent == i);
+    
+    % Update the transforms of the children
+    for j = children
+        model.parent(j) = parent;
+        model.Xtree{j} = model.Xtree{j}*model.Xtree{i};
+    end
+    
+    % Absorb the body into the parent body if it exists
+    if parent > 0
+        % Add inertia to parent
+        X = model.Xtree{i};
+        I = X'*model.I{i}*X;
+        model.I{parent} = model.I{parent} + I;
+    end
+end
+
+% Remove the joints
+i = 1;
+while i <= model.NB
+    if ~strcmp(model.jtype{i}, 'fixed')
+        i = i + 1;
+    else
+        model.NB = model.NB - 1;
+        model.parent(i) = [];
+        model.Xtree(i) = [];
+        model.I(i) = [];
+        model.jtype(i) = [];
+        
+        for j = i:model.NB
+            if model.parent(j) >= i
+                model.parent(j) = model.parent(j) - 1;
+            end
+        end
+    end
+end
+end


### PR DESCRIPTION
Hi, here's a simple add-up for support for continuous joints and fixed joints appearing in the URDF of some of the robot arms.

1. Continuous joints are just revolute joints that can rotate 360 degrees.
2. Fixed joints assume 0 position, velocity, and acceleration all the time, which might be useful to describe complex structures like grippers. An additional function called "remove_fixed_joints" has been added to remove fixed joints and merge bodies that are connected through fixed joints into one body. In "URDF_to_spatialv2_model", it is called by default.

I did not include sufficient tests for the fixed joint features yet. By modifying "jcalc", all functions should still work for a model with fixed joints technically. The robot states still need to include these fixed joints but the states will only be served as placeholders since they will not actually change the position, velocity, and acceleration of the fixed joints.

Please feel free to edit the code directly to match your original style. I'm happy to help with any additional related features. Thanks for your review in advance!